### PR TITLE
Api-Klassen umgestaltet und umbenannt

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -7,6 +7,10 @@
  * @psalm-scope-this rex_addon
  */
 
+use FriendsOfRedaxo\RexQL\Api\Auth;
+use FriendsOfRedaxo\RexQL\Api\GraphQl;
+use FriendsOfRedaxo\RexQL\Api\Proxy;
+
 require_once __DIR__ . '/vendor/autoload.php';
 
 \rex_fragment::addDirectory(\rex_path::src('fragments'));
@@ -17,9 +21,9 @@ rex_perm::register('rexql[graphql]', null, rex_perm::OPTIONS);
 rex_perm::register('rexql[admin]', 'rexql[graphql]');
 
 // API-Klassen registrieren
-rex_api_function::register('rexql_graphql', 'rex_api_rexql_graphql');
-rex_api_function::register('rexql_proxy', 'rex_api_rexql_proxy');
-rex_api_function::register('rexql_auth', 'rex_api_rexql_auth');
+rex_api_function::register('rexql_graphql', GraphQl::class);
+rex_api_function::register('rexql_proxy', Proxy::class);
+rex_api_function::register('rexql_auth', Auth::class);
 
 // Standardkonfiguration setzen
 if (!$this->hasConfig()) {

--- a/lib/api/Auth.php
+++ b/lib/api/Auth.php
@@ -1,11 +1,21 @@
 <?php
 
+namespace FriendsOfRedaxo\RexQL\Api;
+
+use Exception;
+use rex_addon;
+use rex_api_exception;
+use rex_api_function;
+use rex_api_result;
+use rex_file;
+use rex_response;
+
 /**
  * Einfaches Session Token System für rexQL
  * 
  * Für Test-Apps und einfache Frontend-Anwendungen
  */
-class rex_api_rexql_auth extends rex_api_function
+class Auth extends rex_api_function
 {
   protected $published = true;
 

--- a/lib/api/Proxy.php
+++ b/lib/api/Proxy.php
@@ -5,7 +5,20 @@
  * 
  * Ermöglicht sichere Frontend-Integration ohne Exposition der API-Schlüssel
  */
-class rex_api_rexql_proxy extends rex_api_function
+
+namespace FriendsOfRedaxo\RexQL\Api;
+
+use Exception;
+use FriendsOfRedaxo\RexQL\ApiKey;
+use FriendsOfRedaxo\RexQL\Utility;
+use rex;
+use rex_addon;
+use rex_api_exception;
+use rex_api_function;
+use rex_api_result;
+use rex_response;
+
+class Proxy extends rex_api_function
 {
   protected $published = true;
 
@@ -32,23 +45,23 @@ class rex_api_rexql_proxy extends rex_api_function
       }
 
       // API Key anhand Public Key finden
-      $apiKey = FriendsOfRedaxo\RexQL\ApiKey::findByKey($publicKey);
+      $apiKey = ApiKey::findByKey($publicKey);
       if (!$apiKey || $apiKey->getKeyType() !== 'public_private') {
         throw new rex_api_exception('Ungültiger Public Key');
       }
 
       // Domain-Validierung
-      if (!FriendsOfRedaxo\RexQL\Utility::validateDomainRestrictions($apiKey)) {
+      if (!Utility::validateDomainRestrictions($apiKey)) {
         throw new rex_api_exception('Domain nicht erlaubt');
       }
 
       // IP-Validierung
-      if (!FriendsOfRedaxo\RexQL\Utility::validateIpRestrictions($apiKey)) {
+      if (!Utility::validateIpRestrictions($apiKey)) {
         throw new rex_api_exception('IP-Adresse nicht erlaubt');
       }
 
       // HTTPS-Validierung
-      if (!FriendsOfRedaxo\RexQL\Utility::validateHttpsRestrictions($apiKey)) {
+      if (!Utility::validateHttpsRestrictions($apiKey)) {
         throw new rex_api_exception('HTTPS erforderlich');
       }
 
@@ -98,7 +111,7 @@ class rex_api_rexql_proxy extends rex_api_function
   private function validateCustomSessionToken(string $token): bool
   {
     // Verwende das neue Auth-System
-    $sessionData = rex_api_rexql_auth::validateSessionToken($token);
+    $sessionData = Auth::validateSessionToken($token);
     return $sessionData !== null;
   }
 


### PR DESCRIPTION
Ist keine funktionale Änderung, nur eine Anpassung an die Namesspace-Logik.

1) API-Klassen in den Namespace `FriendsOfRedaxo/RexQL/Api` gelegt.
2) Die Klassen umbenannt (statt z.B. `rex_api_rexql_auth` nun `Auth`), da die Erkennbarkeit über den Namensprefix `rex_api` nicht mehr nötig ist. Dateinamen passend dazu.
3) Api-Registrierung in der **boot.php** so geändert, das moderne IDEs und TRexStan die Klasse erkennen können (Class-String statt Literal).
4) In den betroffenen Dateien Use-Statements statt qualifizierter Namespace-Pfade.